### PR TITLE
Fix after-side row order for reordered CSV diffs

### DIFF
--- a/.claude/plans/twinkly-sprouting-garden.md
+++ b/.claude/plans/twinkly-sprouting-garden.md
@@ -1,0 +1,123 @@
+# Fix: After-side row order in reordered CSV diffs
+
+## Context
+
+When CSV rows are reordered, the after (right) side of the diff table displays rows in **before-side order** instead of the actual new file order. Line numbers are correct but visually jumbled. Both Classic UI and Preview UI are affected.
+
+**Root cause:** `matchByKey()` builds `matched[]` by iterating `before[]` in order. `buildSide()` renders both sides using that same order, so the after side inherits the before side's row sequence.
+
+**Decision:** Follow GitHub's native diff layout (diff-order + blank rows) so both sides always have ascending line numbers.
+
+## Expected result for reorder.csv
+
+```
+BEFORE                           | AFTER
+header(1)                        | header(1)
+E001,Tanaka,Engineer...(2) [DEL] | [blank]
+E002,Suzuki,Designer...(3) [DEL] | [blank]
+E003,Yamamoto,PM...(4)     [DEL] | [blank]
+E004,Watanabe...(5)              | E004,Watanabe...(2)
+E005,Ito,QA...(6)          [DEL] | [blank]
+[blank]                          | E001,Lead Eng...(3) [ADD]
+E006,Nakamura...(7)              | E006,Nakamura...(4)
+E007,Kobayashi...(8)       [DEL] | [blank]
+[blank]                          | E003,Yamamoto...(5) [ADD]
+[blank]                          | E002,Suzuki...inactive(6) [ADD]
+E008,Sato...(9)                  | E008,Sato...(7)
+[blank]                          | E005,QA Lead...(8) [ADD]
+[blank]                          | E007,Kobayashi...(9) [ADD]
+[blank]                          | E009,Takahashi...(10) [ADD]
+```
+
+## Changes
+
+### 1. `src/parser/diffParser.ts` — Add alignment info to CsvDiff
+
+Add `DiffAlignment` type and `alignment` field to `CsvDiff` interface:
+
+```typescript
+export interface DiffAlignment {
+  type: "removed" | "added" | "unchanged";
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
+}
+
+export interface CsvDiff {
+  // ... existing fields ...
+  /** Diff-order alignment. One entry per diff text line. */
+  alignment: DiffAlignment[];
+}
+```
+
+Populate in `diffToCsv()` from the input DiffLine[].
+
+### 2. `src/renderer/tableRenderer.ts` — New matching function
+
+#### Step A: `buildRowTokens()` — Normalize raw alignment to logical CSV rows
+
+Convert raw alignment entries (one per diff text line) into row-level tokens (one per parsed CSV row). This correctly handles multiline CSV fields that span multiple diff lines.
+
+```typescript
+interface RowToken {
+  type: "removed" | "added" | "unchanged";
+  beforeIndex: number | null;
+  afterIndex: number | null;
+}
+```
+
+- Build `lineNum → rowIndex` maps from resolved (post-header-slice) `lineNums` arrays
+- Skip null line numbers when building maps
+- Emit rules (strict type validation):
+  - `unchanged` entry → emit only when **both** old and new sides resolve to valid indices
+  - `removed` entry → emit only when old side resolves
+  - `added` entry → emit only when new side resolves
+- Mark consumed indices to avoid duplicates (multiline CSV continuation lines)
+- Non-matching entries (header rows, continuations) → skip silently
+
+#### Step B: `pairBlocks()` — Block pairing with split-layout support
+
+**Critical**: In split layout, `extractDiffLinesFromDom` interleaves removed/added tokens for modified lines (both sides on the same DOM row). Block collection must handle this by collecting **all non-unchanged tokens until the next unchanged** and then separating into removed/added arrays, rather than assuming "consecutive removed then consecutive added."
+
+Pairing rules within each block:
+
+- **1R/1A blocks (special case)**: pair as `"modified"` UNLESS both first-column keys are non-empty and differ (moved row → separate removed/added)
+- **Larger blocks (2+ removed and/or 2+ added)**: apply key-matching rule:
+  - Require non-empty, unique keys within each side of the block
+  - Match by first-column key, verify monotonic added indices
+  - If valid: emit in **merged diff order** using two-cursor merge (flush unmatched removed/added before each anchor)
+  - If invalid: emit all as separate removed/added
+
+#### Step C: `matchByAlignment()` — Build MatchedRow[] from paired tokens
+
+Orchestrates buildRowTokens → pairBlocks → MatchedRow[] conversion.
+Returns `{ rows, consumedBefore, consumedAfter }` for validation.
+
+When converting "unchanged" RowTokens, compare actual CSV data with `arraysEqual()` — emit as `"modified"` if content differs (handles multiline continuation-line edits).
+
+#### Step D: Update `matchRows()` and `renderDiffTable()`
+
+`matchRows()` accepts optional `alignment` parameter. If alignment produces rows that consume all before/after data, use it. Otherwise fall back to existing `matchByKey`/`matchByOrder`.
+
+### 3. No changes needed
+
+- `src/content/observer.ts` — CsvDiff already flows through
+- `syncRowHeights()` — visual-position pairing remains correct
+- `highlightChangedCells()` — matched array indices still correspond to DOM row order
+
+## Implementation notes
+
+### Split layout token interleaving
+
+In Classic/Preview UI split layout, modified lines produce `[removed, added]` pairs per DOM row. For a block like Delta (3 continuation lines) + Epsilon:
+
+**Unified layout alignment**: `DEL DEL DEL DEL ADD ADD ADD` → tokens: `removed removed added added`
+**Split layout alignment**: `DEL+ADD DEL+ADD DEL+ADD DEL` → tokens: `removed added added removed`
+
+The `pairBlocks` function handles both by collecting all non-unchanged tokens to the next unchanged boundary, then separating into removed/added arrays.
+
+## Verification (completed)
+
+- Classic UI unified: reorder.csv ✓, multiline.csv ✓, other files ✓
+- Classic UI split: reorder.csv ✓, multiline.csv ✓, other files ✓
+- Preview UI unified: ✓
+- Preview UI split: ✓

--- a/src/parser/diffParser.ts
+++ b/src/parser/diffParser.ts
@@ -12,11 +12,19 @@ export interface DiffLine {
   newLineNumber: number | null;
 }
 
+export interface DiffAlignment {
+  type: "removed" | "added" | "unchanged";
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
+}
+
 export interface CsvDiff {
   before: string[][];
   after: string[][];
   beforeLineNumbers: Array<number | null>;
   afterLineNumbers: Array<number | null>;
+  /** Diff-order alignment for rendering. One entry per diff text line. */
+  alignment: DiffAlignment[];
 }
 
 /**
@@ -103,6 +111,11 @@ export function diffToCsv(lines: DiffLine[]): CsvDiff {
     after: after.data,
     beforeLineNumbers: before.lineNumbers,
     afterLineNumbers: after.lineNumbers,
+    alignment: lines.map((line) => ({
+      type: line.type,
+      oldLineNumber: line.oldLineNumber,
+      newLineNumber: line.newLineNumber,
+    })),
   };
 }
 

--- a/src/renderer/tableRenderer.ts
+++ b/src/renderer/tableRenderer.ts
@@ -480,21 +480,17 @@ function tryPairBlock(
   beforeData: string[][],
   afterData: string[][],
 ): PairedToken[] {
-  // 1R/1A special case
+  // 1R/1A: always pair as modified (position-based, like GitHub split view).
+  // Adjacent removed+added in the diff are the same logical edit regardless
+  // of whether the first column changed — moved rows are separated by context.
   if (removedBlock.length === 1 && addedBlock.length === 1) {
-    const bKey = beforeData[removedBlock[0].beforeIndex!]?.[0] ?? "";
-    const aKey = afterData[addedBlock[0].afterIndex!]?.[0] ?? "";
-    // Pair unless both keys are non-empty and differ (moved row)
-    if (bKey === "" || aKey === "" || bKey === aKey) {
-      return [
-        {
-          type: "modified",
-          beforeIndex: removedBlock[0].beforeIndex,
-          afterIndex: addedBlock[0].afterIndex,
-        },
-      ];
-    }
-    return emitOriginalOrder(blockTokens);
+    return [
+      {
+        type: "modified",
+        beforeIndex: removedBlock[0].beforeIndex,
+        afterIndex: addedBlock[0].afterIndex,
+      },
+    ];
   }
 
   // Larger blocks: try key-based monotonic pairing

--- a/src/renderer/tableRenderer.ts
+++ b/src/renderer/tableRenderer.ts
@@ -383,6 +383,10 @@ function buildRowTokens(
   const consumedA = new Set<number>();
   const tokens: RowToken[] = [];
 
+  // Each alignment entry maps a physical diff line to a logical CSV row via
+  // line-number lookup. Entries that don't resolve (header rows sliced off by
+  // resolveHeaderAndData, or continuation lines of multi-line CSV fields whose
+  // start line was already consumed) are silently skipped.
   for (const entry of alignment) {
     if (entry.type === "unchanged") {
       const bi =

--- a/src/renderer/tableRenderer.ts
+++ b/src/renderer/tableRenderer.ts
@@ -2,7 +2,7 @@
  * Renders side-by-side (Before / After) diff tables from parsed CSV data.
  */
 
-import type { CsvDiff } from "../parser/diffParser";
+import type { CsvDiff, DiffAlignment } from "../parser/diffParser";
 import {
   appendTextWithBreaks,
   computeInlineDiff,
@@ -144,6 +144,7 @@ export function renderDiffTable(
     after.data,
     before.lineNums,
     after.lineNums,
+    diff.alignment,
   );
 
   container.appendChild(
@@ -331,12 +332,311 @@ export function matchRows(
   after: string[][],
   beforeLineNums: Array<number | null>,
   afterLineNums: Array<number | null>,
+  alignment?: DiffAlignment[],
 ): MatchedRow[] {
+  if (alignment) {
+    const result = matchByAlignment(
+      alignment,
+      before,
+      after,
+      beforeLineNums,
+      afterLineNums,
+    );
+    if (
+      result.consumedBefore === before.length &&
+      result.consumedAfter === after.length
+    ) {
+      return result.rows;
+    }
+  }
   if (isFirstColumnKey(before, after)) {
     return matchByKey(before, after, beforeLineNums, afterLineNums);
   }
   return matchByOrder(before, after, beforeLineNums, afterLineNums);
 }
+
+// --- Alignment-based matching ---
+
+interface RowToken {
+  type: "removed" | "added" | "unchanged";
+  beforeIndex: number | null;
+  afterIndex: number | null;
+}
+
+function buildRowTokens(
+  alignment: DiffAlignment[],
+  beforeLineNums: Array<number | null>,
+  afterLineNums: Array<number | null>,
+): RowToken[] {
+  const bMap = new Map<number, number>();
+  for (let i = 0; i < beforeLineNums.length; i++) {
+    const ln = beforeLineNums[i];
+    if (ln != null) bMap.set(ln, i);
+  }
+  const aMap = new Map<number, number>();
+  for (let i = 0; i < afterLineNums.length; i++) {
+    const ln = afterLineNums[i];
+    if (ln != null) aMap.set(ln, i);
+  }
+
+  const consumedB = new Set<number>();
+  const consumedA = new Set<number>();
+  const tokens: RowToken[] = [];
+
+  for (const entry of alignment) {
+    if (entry.type === "unchanged") {
+      const bi =
+        entry.oldLineNumber != null ? bMap.get(entry.oldLineNumber) : undefined;
+      const ai =
+        entry.newLineNumber != null ? aMap.get(entry.newLineNumber) : undefined;
+      if (bi === undefined || ai === undefined) continue;
+      if (consumedB.has(bi) || consumedA.has(ai)) continue;
+      consumedB.add(bi);
+      consumedA.add(ai);
+      tokens.push({ type: "unchanged", beforeIndex: bi, afterIndex: ai });
+    } else if (entry.type === "removed") {
+      const bi =
+        entry.oldLineNumber != null ? bMap.get(entry.oldLineNumber) : undefined;
+      if (bi === undefined || consumedB.has(bi)) continue;
+      consumedB.add(bi);
+      tokens.push({ type: "removed", beforeIndex: bi, afterIndex: null });
+    } else {
+      const ai =
+        entry.newLineNumber != null ? aMap.get(entry.newLineNumber) : undefined;
+      if (ai === undefined || consumedA.has(ai)) continue;
+      consumedA.add(ai);
+      tokens.push({ type: "added", beforeIndex: null, afterIndex: ai });
+    }
+  }
+
+  return tokens;
+}
+
+interface PairedToken {
+  type: "removed" | "added" | "modified" | "unchanged";
+  beforeIndex: number | null;
+  afterIndex: number | null;
+}
+
+function pairBlocks(
+  tokens: RowToken[],
+  beforeData: string[][],
+  afterData: string[][],
+): PairedToken[] {
+  const result: PairedToken[] = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    if (tokens[i].type === "unchanged") {
+      result.push(tokens[i]);
+      i++;
+      continue;
+    }
+
+    // Collect all non-unchanged tokens until the next unchanged (or end).
+    // Split layout may interleave removed/added, so we keep the original
+    // order for fallback while separating into removed/added for pairing.
+    const blockTokens: RowToken[] = [];
+    const removedBlock: RowToken[] = [];
+    const addedBlock: RowToken[] = [];
+    while (i < tokens.length && tokens[i].type !== "unchanged") {
+      blockTokens.push(tokens[i]);
+      if (tokens[i].type === "removed") {
+        removedBlock.push(tokens[i]);
+      } else {
+        addedBlock.push(tokens[i]);
+      }
+      i++;
+    }
+
+    if (removedBlock.length === 0) {
+      result.push(...addedBlock);
+      continue;
+    }
+
+    if (addedBlock.length === 0) {
+      result.push(...removedBlock);
+      continue;
+    }
+
+    result.push(
+      ...tryPairBlock(
+        removedBlock,
+        addedBlock,
+        blockTokens,
+        beforeData,
+        afterData,
+      ),
+    );
+  }
+
+  return result;
+}
+
+function tryPairBlock(
+  removedBlock: RowToken[],
+  addedBlock: RowToken[],
+  blockTokens: RowToken[],
+  beforeData: string[][],
+  afterData: string[][],
+): PairedToken[] {
+  // 1R/1A special case
+  if (removedBlock.length === 1 && addedBlock.length === 1) {
+    const bKey = beforeData[removedBlock[0].beforeIndex!]?.[0] ?? "";
+    const aKey = afterData[addedBlock[0].afterIndex!]?.[0] ?? "";
+    // Pair unless both keys are non-empty and differ (moved row)
+    if (bKey === "" || aKey === "" || bKey === aKey) {
+      return [
+        {
+          type: "modified",
+          beforeIndex: removedBlock[0].beforeIndex,
+          afterIndex: addedBlock[0].afterIndex,
+        },
+      ];
+    }
+    return emitOriginalOrder(blockTokens);
+  }
+
+  // Larger blocks: try key-based monotonic pairing
+  // Check keys are non-empty and unique within each side
+  const rKeys = new Map<string, number>();
+  for (let j = 0; j < removedBlock.length; j++) {
+    const key = beforeData[removedBlock[j].beforeIndex!]?.[0] ?? "";
+    if (!key || rKeys.has(key)) return emitOriginalOrder(blockTokens);
+    rKeys.set(key, j);
+  }
+  const aKeys = new Map<string, number>();
+  for (let j = 0; j < addedBlock.length; j++) {
+    const key = afterData[addedBlock[j].afterIndex!]?.[0] ?? "";
+    if (!key || aKeys.has(key)) return emitOriginalOrder(blockTokens);
+    aKeys.set(key, j);
+  }
+
+  // Match by key and check monotonicity
+  const matches: Array<{ rIdx: number; aIdx: number }> = [];
+  for (const [key, rIdx] of rKeys) {
+    const aIdx = aKeys.get(key);
+    if (aIdx !== undefined) {
+      matches.push({ rIdx, aIdx });
+    }
+  }
+  matches.sort((a, b) => a.aIdx - b.aIdx);
+
+  // Verify monotonic on removed side
+  let lastR = -1;
+  for (const m of matches) {
+    if (m.rIdx < lastR) return emitOriginalOrder(blockTokens);
+    lastR = m.rIdx;
+  }
+
+  // Two-cursor merge: emit in diff order
+  const matchedR = new Set(matches.map((m) => m.rIdx));
+  const matchedA = new Set(matches.map((m) => m.aIdx));
+  const result: PairedToken[] = [];
+
+  let nextR = 0;
+  let nextA = 0;
+  for (const { rIdx, aIdx } of matches) {
+    // Flush unmatched removed before this anchor
+    while (nextR < rIdx) {
+      if (!matchedR.has(nextR)) {
+        result.push(removedBlock[nextR]);
+      }
+      nextR++;
+    }
+    // Flush unmatched added before this anchor
+    while (nextA < aIdx) {
+      if (!matchedA.has(nextA)) {
+        result.push(addedBlock[nextA]);
+      }
+      nextA++;
+    }
+    // Emit modified pair
+    result.push({
+      type: "modified",
+      beforeIndex: removedBlock[rIdx].beforeIndex,
+      afterIndex: addedBlock[aIdx].afterIndex,
+    });
+    nextR = rIdx + 1;
+    nextA = aIdx + 1;
+  }
+
+  // Flush remaining
+  while (nextR < removedBlock.length) {
+    if (!matchedR.has(nextR)) {
+      result.push(removedBlock[nextR]);
+    }
+    nextR++;
+  }
+  while (nextA < addedBlock.length) {
+    if (!matchedA.has(nextA)) {
+      result.push(addedBlock[nextA]);
+    }
+    nextA++;
+  }
+
+  return result;
+}
+
+function emitOriginalOrder(blockTokens: RowToken[]): PairedToken[] {
+  return [...blockTokens];
+}
+
+function matchByAlignment(
+  alignment: DiffAlignment[],
+  beforeData: string[][],
+  afterData: string[][],
+  beforeLineNums: Array<number | null>,
+  afterLineNums: Array<number | null>,
+): { rows: MatchedRow[]; consumedBefore: number; consumedAfter: number } {
+  const tokens = buildRowTokens(alignment, beforeLineNums, afterLineNums);
+  const paired = pairBlocks(tokens, beforeData, afterData);
+
+  const consumedB = new Set<number>();
+  const consumedA = new Set<number>();
+  const rows: MatchedRow[] = [];
+
+  for (const p of paired) {
+    const bi = p.beforeIndex;
+    const ai = p.afterIndex;
+    const beforeRow = bi != null ? beforeData[bi] : null;
+    const afterRow = ai != null ? afterData[ai] : null;
+
+    let type: MatchedRow["type"];
+    if (p.type === "removed") {
+      type = "removed";
+    } else if (p.type === "added") {
+      type = "added";
+    } else {
+      // "modified" or "unchanged" — verify with actual content.
+      // Handles: multiline continuation edits (unchanged token, different content)
+      // and reorder-only anchors (modified token, identical content).
+      type =
+        beforeRow && afterRow && arraysEqual(beforeRow, afterRow)
+          ? "unchanged"
+          : "modified";
+    }
+
+    rows.push({
+      before: beforeRow,
+      after: afterRow,
+      type,
+      beforeLineNumber: bi != null ? lineNumAt(beforeLineNums, bi) : null,
+      afterLineNumber: ai != null ? lineNumAt(afterLineNums, ai) : null,
+    });
+
+    if (bi != null) consumedB.add(bi);
+    if (ai != null) consumedA.add(ai);
+  }
+
+  return {
+    rows,
+    consumedBefore: consumedB.size,
+    consumedAfter: consumedA.size,
+  };
+}
+
+// --- Key/order-based matching (fallback) ---
 
 function isFirstColumnKey(before: string[][], after: string[][]): boolean {
   if (before.length === 0 && after.length === 0) return false;


### PR DESCRIPTION
## Summary

- Follow GitHub's native diff layout (diff-order + blank rows) instead of key-based row matching, so both sides always have ascending line numbers
- Add alignment-based matching (`buildRowTokens` → `pairBlocks` → `matchByAlignment`) that preserves the original diff order
- Handle split-layout token interleaving where removed/added entries alternate for modified lines
- Within consecutive removed+added blocks, pair rows by first-column key (monotonic check) to preserve inline diff highlighting for in-place edits

Fixes the bug where reordered CSV rows displayed in the before side's order on the after side, causing jumbled line numbers.

## Test plan

- [x] `reorder.csv` on PR #2: after-side line numbers ascending, blank rows for moved rows
- [x] `multiline.csv` on PR #2: no false move detection for rows with newline changes
- [x] Other CSV files on PR #2: no regressions (sample.csv, column-change.csv, large-file.csv)
- [x] Verified on Classic UI unified, Classic UI split, Preview UI unified, Preview UI split

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diff alignment tracking to improve accuracy of line-by-line comparisons between versions.

* **Refactor**
  * Optimized row-matching logic for better pairing of added, removed, and modified lines in diff visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->