### PR TITLE
fix: render CSV header row on Firefox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,4 +63,4 @@ To verify extension behavior in the browser, use `playwright-cli attach --extens
 - DOM-based diff parsing (not GitHub REST API) to avoid authentication
 - Side-by-side (Before / After) table layout
 - Match CSV rows by first column (ID/key) when possible; fall back to line-order matching
-- Minimal permissions: no host permissions beyond `github.com`
+- Minimal permissions: Chrome declares no host permissions (content-script `fetch` inherits page privileges). Firefox content-script `fetch` runs with the extension principal, so cross-origin requests require explicit host permissions — declared **for the Firefox build only** in `wxt.config.ts` (`github.com` + `raw.githubusercontent.com`, the latter being the redirect target of `github.com/.../raw/...`)

--- a/src/content/headerFetcher.ts
+++ b/src/content/headerFetcher.ts
@@ -58,7 +58,9 @@ async function doFetch(
     .map((seg) => encodeURIComponent(seg))
     .join("/");
 
-  const baseUrl = `/${owner}/${repo}/raw/${ref}/${encodedPath}`;
+  // Use an absolute URL: Firefox content scripts resolve relative URLs against
+  // the extension origin (moz-extension://), not the page, so fetch() throws.
+  const baseUrl = `${location.origin}/${owner}/${repo}/raw/${ref}/${encodedPath}`;
   let rangeEnd = INITIAL_RANGE;
 
   while (rangeEnd <= MAX_RANGE) {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -7,16 +7,34 @@ export default defineConfig({
   autoIcons: {
     baseIconPath: "assets/icon.svg",
   },
-  manifest: {
-    name: "GitHub Better CSV Diff",
-    description: "Renders CSV file diffs as side-by-side tables on GitHub",
-    browser_specific_settings: {
-      gecko: {
-        id: "github-better-csv-diff@letconst.dev",
-        data_collection_permissions: {
-          required: ["none"],
+  manifest: ({ browser, manifestVersion }) => {
+    // Firefox content scripts run fetch() with the extension's principal, so
+    // cross-origin requests require explicit host permissions. Chrome inherits
+    // the page's privileges, so it works without them. These hosts cover the
+    // CSV header fetch: github.com/.../raw redirects to raw.githubusercontent.com.
+    const hostPatterns = [
+      "https://github.com/*",
+      "https://raw.githubusercontent.com/*",
+    ];
+    const firefoxHostPermissions =
+      browser === "firefox"
+        ? manifestVersion === 3
+          ? { host_permissions: hostPatterns }
+          : { permissions: hostPatterns }
+        : {};
+
+    return {
+      name: "GitHub Better CSV Diff",
+      description: "Renders CSV file diffs as side-by-side tables on GitHub",
+      browser_specific_settings: {
+        gecko: {
+          id: "github-better-csv-diff@letconst.dev",
+          data_collection_permissions: {
+            required: ["none"],
+          },
         },
       },
-    },
+      ...firefoxHostPermissions,
+    };
   },
 });


### PR DESCRIPTION
## Summary

The header-fetch feature (fetching a CSV's header row when a diff starts partway through the file) worked on Chrome but silently failed on Firefox. This PR fixes two distinct root causes behind the Firefox failure.

## Root causes

The failure was two-layered — both needed fixing:

1. **`TypeError: ... is not a valid URL`** — The fetch target was a root-relative URL (`/owner/repo/raw/...`). Firefox content scripts resolve relative URLs against the extension origin (`moz-extension://`) instead of the page, so the URL was invalid. Chrome resolves against the page, so it worked there.

2. **`NetworkError when attempting to fetch resource`** — Firefox content scripts run `fetch()` with the extension principal, so cross-origin requests require explicit host permissions. The manifest declared none, so the request to `github.com/.../raw/...` (which redirects to `raw.githubusercontent.com`) was blocked. Chrome inherits the page's privileges and needs no host permissions.

## Changes

- **`fix`**: prefix `location.origin` to build an absolute URL that resolves consistently in both browsers.
- **`fix`**: declare host permissions (`github.com` + `raw.githubusercontent.com`) for the **Firefox build only**, via WXT's per-browser manifest function. Chrome stays at minimal permissions, preserving the project's minimal-permission decision.
- **`docs`**: update CLAUDE.md to document the cross-browser content-script `fetch` principal difference that drove the manifest design.

## Verification

- Page-context fetch on Firefox confirmed working (status 206/200, CORS OK) — isolating the failure to the content-script principal.
- Both `npm run build` (Chrome MV3) and `npm run build:firefox` (Firefox MV2) succeed.
- Generated manifests verified: Firefox MV2 gains `permissions: ["https://github.com/*", "https://raw.githubusercontent.com/*"]`; Chrome MV3 declares no host permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-browser compatibility by refining how the extension handles GitHub data fetching across Chrome and Firefox with appropriate permission configurations for each browser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letconst/github-better-csv-diff/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->