### PR TITLE
feat: make the CSV diff column header sticky

### DIFF
--- a/.claude/plans/ok-plan-sharded-truffle.md
+++ b/.claude/plans/ok-plan-sharded-truffle.md
@@ -1,0 +1,234 @@
+# Plan: Sticky CSV column header (issue #11)
+
+## Context
+
+When a CSV diff has many rows, scrolling moves the column header out of view, so reviewers
+lose track of which column is which. Issue #11 asks for the rendered CSV table's **column
+header row** to stay visible (sticky), pinned in the viewport **directly below GitHub's own
+sticky file-header bar**, stacking with GitHub's sticky elements — for all UIs/layouts.
+
+The CSS already declares `position: sticky; top: 0` on the header `<th>` (`diff-table.css:26-28`),
+but it does nothing. **Root cause (verified live in-browser):** `.csv-diff-side` and
+`.csv-diff-container` have `overflow-x: auto` (`diff-table.css:6`, `:17`). Per the CSS overflow
+spec, a non-`visible` value on one axis forces the other axis from `visible` to `auto`, so both
+become vertical scroll containers. They have no height constraint (`scrollHeight === clientHeight`),
+so they never actually scroll vertically — but they **trap** the `th`'s sticky: its nearest
+scroll-container ancestor is `.csv-diff-side`, which never scrolls, so the header just scrolls
+away with the document.
+
+**Unavoidable constraint:** a header that sticks to the viewport must have no scroll-container
+ancestor up to `<html>`; but wide tables need a horizontal scroll container, which (per the same
+spec rule) is always also a vertical scroll container. Therefore the header must **not** be a
+descendant of the horizontal scroller → header and body must live in separate subtrees (separate
+tables) with column widths and horizontal scroll synced manually. This is the standard
+**frozen-header** data-grid pattern.
+
+**Verified facts driving the design:**
+- A test element placed in `.csv-diff-wrapper` (outside the overflow box) with
+  `position: sticky; top: 100px` pinned correctly at viewport y=100 during scroll, exactly below
+  GitHub's file header.
+- GitHub's sticky file-header differs per UI; the pin offset must be computed at **runtime**:
+  - Classic: `.file-header`, `sticky top:60px z:2`, height ≈41 → pins at ≈101px
+  - Preview: `div[class*="diffHeaderWrapper"]`, `sticky top:58px z:5`, height ≈42 → pins at ≈100px
+  - Identical across unified AND split (our overlay is always side-by-side regardless of GitHub's
+    native layout).
+
+**Scope decisions (confirmed with user):**
+- Only the **column header row** is sticky. The per-side "Before"/"After" label scrolls away.
+- Do **not** remove the Before/After label (possible future change, out of scope here).
+
+## Approach
+
+Restructure each side into a frozen-header layout, sync column widths + horizontal scroll in JS,
+and set the sticky `top` from GitHub's file-header geometry at runtime.
+
+New per-side DOM (produced by `buildSide` in `tableRenderer.ts`):
+
+```
+div.csv-diff-side                  (overflow: visible — no longer a scroller; min-width: 0)
+  div.csv-diff-header              "Before"/"After" label (unchanged; scrolls away)
+  div.csv-diff-header-strip        position: sticky; top: var(--csv-diff-sticky-top); overflow: hidden; z-index: 3
+    table.csv-diff-header-table    table-layout: fixed
+      colgroup (maxCols+1 <col>)   width carrier
+      thead > tr                   th.csv-diff-line-num "#" + per-column th
+  div.csv-diff-body                overflow-x: auto   (the ONLY scroll container per side)
+    table.csv-diff-body-table      table-layout: fixed
+      colgroup (maxCols+1 <col>)   width carrier
+      tbody                        data rows (td.csv-diff-line-num + data td)
+```
+
+## Changes
+
+### 1. `src/renderer/tableRenderer.ts`
+- Split `buildSide` (`:191-274`) into `buildHeaderTable(headers, maxCols, isLoading)` and
+  `buildBodyTable(matched, side, maxCols)`; assemble the side as label + header-strip + body.
+  Add a `<colgroup>` of `maxCols+1` `<col>` to both tables.
+  - Loading mode (`:211-217`): the body table still renders its data rows as normal; only the
+    header table shows the `colSpan` "Loading…" placeholder (not "header only"). Skip width sync
+    while loading; the real column structure comes from the post-fetch re-render.
+- New exported `syncColumnWidths(container: HTMLElement): void`, mirroring `syncRowHeights`'s
+  clear→read→write pattern, run **per side independently** (Before/After widths need not match;
+  only intra-side header↔body must align):
+  1. Guard `isConnected` + `getClientRects().length` (like `syncRowHeights:83`).
+  2. Clear: set both tables `table-layout: auto`, clear each table's own `style.width` AND all
+     `<col>` widths → true natural widths (otherwise a later resync measures against the stale
+     fixed px width applied by the previous write pass).
+  3. Read: per column, `max(headerCellWidth, firstBodyRowCellWidth)` (clipping avoidance; if no
+     body rows, header width only).
+  4. Write: `table-layout: fixed`; set identical `col.style.width` on both colgroups; set an
+     **explicit JS-computed px total width** (sum of column widths) on BOTH the header and body
+     tables (NOT `max-content` — too loose for two separate fixed-layout tables; identical explicit
+     totals guarantee matching `scrollLeft` ranges). CSS stays limited to border model +
+     `table-layout: fixed`.
+  - **Run only post-insertion.** Both sync functions are connectivity-gated (`syncRowHeights:83`),
+    and `renderDiffTable` returns a **detached** node (`:117`), so calling them there is a no-op.
+    Call from the post-insertion sites in §4 only (initial inject, async rerender, toggle-back).
+- **Update `syncRowHeights` (`:82-115`):** change selector `.csv-diff-side table` (`:85`) →
+  `.csv-diff-body-table`; keep the `length !== 2` guard. (Header rows are no longer height-paired.)
+- Retarget scroll sync (`:173-186`): the scroll container is now `.csv-diff-body`. On its `scroll`
+  (keep the `syncing` guard): set the other side's `.csv-diff-body.scrollLeft` AND both sides'
+  `.csv-diff-header-strip.scrollLeft` to `this.scrollLeft` (header strip is `overflow:hidden`,
+  programmatically scrolled). **Use `scrollLeft` only — do NOT use a `translateX` fallback**: a
+  whole-table transform would drag the frozen sticky-left `#` line-num column off too. (If a
+  fallback ever proves necessary, it must translate only the non-line-num columns.)
+- `highlightChangedCells` (`:276-322`): **no change** (queries `tbody tr`, indexes `children[c+1]`;
+  body line-num stays at `children[0]`). Runs before `syncColumnWidths` in `renderDiffTable` —
+  correct, since it rewrites cell content that must be measured after.
+- `renderDiffTable` runs **only** `highlightChangedCells` (it returns a detached node; the two sync
+  functions are connectivity-gated and would no-op). All measurement happens post-insertion in §4,
+  ordered `syncColumnWidths` → `syncRowHeights` (widths affect wrapping/heights).
+
+### 2. `src/styles/diff-table.css`
+- Remove `overflow-x: auto` from `.csv-diff-container` (`:6`) and `.csv-diff-side` (`:17`); add
+  `min-width: 0` to `.csv-diff-side`.
+- Remove `position: sticky; top: 0` from `.csv-diff-side th` (`:26-28`); keep its visual styling
+  and re-scope to also cover `.csv-diff-header-table th`.
+- Replace `.csv-diff-side table { width: 100% }` (`:20-24`): drop the `width` rule — JS sets the
+  explicit px total width on both tables (see §1 write pass). CSS keeps only border model
+  (`border-collapse: separate; border-spacing: 0`) + `table-layout: fixed` on the two new table
+  classes.
+- Add:
+  ```css
+  .csv-diff-header-strip { position: sticky; top: var(--csv-diff-sticky-top, 0px);
+    overflow: hidden; z-index: 3; background: var(--bgColor-muted, #f6f8fa); }
+  .csv-diff-body { overflow-x: auto; }
+  .csv-diff-header-table, .csv-diff-body-table { border-collapse: separate; border-spacing: 0;
+    table-layout: fixed; }
+  .csv-diff-header-table th { white-space: nowrap; }   /* report full width, don't wrap/under-measure */
+  ```
+- **z-index strategy** (sticky-top header × sticky-left line-num intersection):
+  - Body data `td`: auto. Body sticky-left `.csv-diff-line-num` (`:149-151`): keep `z-index: 1`.
+  - `.csv-diff-header-strip`: `z-index: 3` (separate later-DOM sticky subtree → whole header paints
+    above all body cells, incl. the sticky-left body line-num column).
+  - Replace `th.csv-diff-line-num { z-index: 2 }` (`:154-158`) with the header table's frozen
+    top-left corner: `.csv-diff-header-table th.csv-diff-line-num { position: sticky; left: 0; z-index: 2; }`.
+  - Backgrounds stay opaque (line-num column already opaque `:144`; header strip bg set above).
+- Issue's "subtle bottom border or shadow" cue: keep the existing header `border-bottom` and add a
+  subtle `box-shadow` on `.csv-diff-header-strip`.
+- Flash-prevention rule (`:122-126`): unaffected.
+
+### 3. `src/parser/uiConfig.ts`
+- Add to `UiConfig` (`:6-23`): `stickyFileHeaderSelector: string;`
+  - `PREVIEW_UI` (`:25`): `'div[class*="diffHeaderWrapper"]'`
+  - `CLASSIC_UI` (`:47`): `'.file-header'` (same node as `headerSelector` here, but keep distinct —
+    Preview differs; semantics differ).
+
+### 4. `src/content/observer.ts`
+- New `updateStickyTopOffset(container, wrapper, config)`:
+  `el = container.querySelector(config.stickyFileHeaderSelector)`;
+  `offset = (Number.parseFloat(getComputedStyle(el).top) || 0) + el.getBoundingClientRect().height`
+  (**coerce** — `top` resolves to `"auto"` → `NaN` if the selector hits the wrong element);
+  `wrapper.style.setProperty("--csv-diff-sticky-top", offset + "px")`. If not found: `0px` +
+  `console.warn` (degrades to viewport-top sticky).
+- Rerun `updateStickyTopOffset` not only via the file-header ResizeObserver but also on a single
+  shared `window` `resize` listener — GitHub's sticky `top` can change at responsive breakpoints
+  **without** a header-height change (which a ResizeObserver would miss).
+- `injectTableOverlay` (`:466-520`), after `diffBody.prepend(wrapper)` (`:517`):
+  `updateStickyTopOffset(...)`; `syncColumnWidths(tableElement)`; `syncRowHeights(tableElement)`;
+  register ResizeObservers.
+- Toggle-back branch (`:505-510`): also `syncColumnWidths` (before `syncRowHeights`) +
+  `updateStickyTopOffset` (measurements read 0 while `display:none`).
+- `fetchAndRerender` after `oldContainer.replaceWith(newTable)` (`:334`): disconnect this
+  container's old body/header observers, register new ones, then
+  `syncColumnWidths(newTable)` + `syncRowHeights(newTable)` + `updateStickyTopOffset`. Keep the
+  `wrapper.isConnected` guard (`:320`).
+- **Shared visibility guard:** every resync entry point (RO-driven width sync, top-offset, and the
+  manual toggle-back) must first check `wrapper.isConnected && wrapper.style.display !== "none"` and
+  bail otherwise — measuring a hidden/detached wrapper reads 0. (Not just inside the toggle-back
+  path, where the plan previously assumed it.)
+- **ResizeObserver registry + teardown:**
+  - Module-level `Map<HTMLElement /* container */, PerContainerState>`, **keyed by `container`**
+    (persists across collapse/expand; the wrapper does not). `PerContainerState =
+    { observers: ResizeObserver[]; rafId: number | null; syncing: boolean; lastWidths: number[][];
+    lastTop: number }` — a bare `ResizeObserver[]` is not enough for the feedback-loop mitigation.
+  - Per wrapper: one observer per `.csv-diff-body` (re-runs `syncColumnWidths` **then**
+    `syncRowHeights` — width changes alter wrapping/heights, so the two sides drift otherwise;
+    guarded) + one on the GitHub file-header (re-runs `updateStickyTopOffset`).
+  - Mitigate feedback loops using that state: ignore RO callbacks while `syncing`; bail when the
+    newly-measured widths/top equal `lastWidths`/`lastTop`; coalesce writes in a single
+    `requestAnimationFrame` (store/replace `rafId`).
+  - `disconnectObserver` (`:84-95`): for every entry, disconnect all observers **and** `cancelAnimationFrame(rafId)`,
+    then clear map (next to existing cache clears).
+  - `processExistingDiffs` (`:108-116`): when `PROCESSED_ATTR` set but `.csv-diff-wrapper` gone,
+    disconnect+cancel-rAF+remove that container's state (observed bodies are detached → would leak).
+    On re-process, always tear down old state for the container before registering new observers.
+  - **Restored-DOM recovery (do NOT early-continue blindly):** `disconnectObserver` runs on
+    `turbo:before-cache`/`pjax:start` (`:43-45`), clearing the state map; a Turbo snapshot/bfcache
+    restore can bring back DOM that still has the wrapper + `PROCESSED_ATTR` **but with all
+    JS-attached listeners stripped** (snapshots serialize markup only) — i.e. the Before/After +
+    header-strip `scroll` handlers (`tableRenderer.ts:173-184`) and the toggle `click` handler
+    (`observer.ts:496-511`) are gone, in addition to the missing observers. The current "wrapper
+    present → `continue`" branch (`:110-111`) leaves all of these broken. Fix: if the wrapper exists
+    **but the container has no live `PerContainerState`**, do a **full re-init** rather than a
+    partial re-bind — remove the stale wrapper (as in the "wrapper gone" path) and fall through to
+    `processCsvDiffBlock`, which re-renders + re-injects and thereby re-attaches the scroll/toggle
+    listeners and re-registers the observers (+ reruns offset/width/height sync). This is simpler
+    and more robust than surgically re-adding observers + listeners onto the restored DOM.
+
+## Feature interactions
+- **Multiline cells** (`setTextWithBreaks`/`appendTextWithBreaks`): unchanged; `auto`-layout read
+  captures true `<br>` widths; row-height sync runs after.
+- **Inline diff highlighting**: unchanged (see §1).
+- **Raw Diff toggle / async header re-render**: covered by re-syncs above.
+- **Firefox MV2 vs Chrome MV3**: `ResizeObserver`, `getComputedStyle`, `scrollLeft`, CSS custom
+  properties all supported; no manifest/permission changes.
+
+## Top risks
+1. **`syncRowHeights` selector breakage (certain):** 2 tables → 4. Must retarget to
+   `.csv-diff-body-table` or row alignment silently breaks.
+2. **ResizeObserver feedback loop:** body observer fires when width-sync writes widths. Guard +
+   equality bail + rAF coalescing.
+3. **Header/body column drift:** both colgroups need identical per-column + total widths and
+   `table-layout: fixed`. Test wide many-column tables.
+4. **Measurement while hidden / pre-font-load:** widths read 0 when collapsed/raw. Covered by
+   toggle-back re-sync + body ResizeObserver; consider a `document.fonts.ready` trigger.
+5. **GitHub markup drift for `div[class*="diffHeaderWrapper"]`:** `0px` fallback keeps it
+   functional; log a warning.
+6. **Scrollbar gutter mismatch** (body has h-scrollbar, header strip doesn't): cosmetic; if needed
+   use `scrollbar-gutter` or pad the strip.
+
+## Verification (manual — no test suite in repo)
+Build (`npm run build` / `npm run build:firefox`), load unpacked, then per `CLAUDE.md` use
+`playwright-cli attach --extension` against PR #2 (`test/csv-diff-demo`). Confirm in **all four**
+combos (classic/unified, classic/split, preview/unified, preview/split):
+- Scroll the page so a CSV file diff is cut off at the top → the column header pins directly below
+  GitHub's file-header bar (≈100–101px) and stays while body rows scroll under it; un-pins when the
+  file scrolls past.
+- Horizontal scroll: header columns stay aligned with body columns; Before/After stay locked; the
+  sticky-left line-num column and the frozen top-left corner render above body cells.
+- Exercise: wide many-column CSV (h-scroll + alignment), multiline cells, modified-row inline
+  diffs, collapse/expand cycles (no ResizeObserver leak — spot-check via DevTools), async-fetched
+  headers, light + dark themes.
+- If no sufficiently wide sample exists, add one to `example/` via the PR #2 test-sample flow in
+  `CLAUDE.local.md`.
+
+## Commit breakdown (per CLAUDE.local.md context-boundary policy)
+Branch `feature/sticky-csv-header` from `origin/main` after fetch. Suggested order:
+1. `feat: add stickyFileHeaderSelector to UiConfig` (uiConfig.ts)
+2. `refactor: split CSV table into separate header/body tables` (tableRenderer.ts DOM restructure +
+   `syncRowHeights` selector fix, behavior-preserving where possible)
+3. `feat: sync CSV column widths + horizontal scroll across header/body` (`syncColumnWidths`, scroll
+   retarget)
+4. `feat: pin CSV column header below GitHub file header` (CSS sticky/z-index + `updateStickyTopOffset`)
+5. `feat: track file-header height + body width via ResizeObserver` (observer wiring + teardown)
+Plan file committed **last** (per `CLAUDE.md`).

--- a/src/content/observer.ts
+++ b/src/content/observer.ts
@@ -315,7 +315,18 @@ function processExistingDiffs(): void {
         // wrapper and fall through to a full re-init, which re-renders +
         // re-injects and thereby re-attaches scroll/toggle listeners and
         // re-registers observers.
+        //
+        // First un-hide the original diff children: injectTableOverlay hid them
+        // with inline display:none, which the snapshot preserved. Restoring them
+        // before removing the wrapper guarantees the raw diff is visible if the
+        // re-init below early-returns (e.g. collapsed file, no diff lines).
+        const diffBody = wrapper.parentElement;
         wrapper.remove();
+        if (diffBody) {
+          for (const child of diffBody.children) {
+            (child as HTMLElement).style.display = "";
+          }
+        }
       }
 
       // Wrapper gone (collapse/re-expand rebuild, or removed just above).

--- a/src/content/observer.ts
+++ b/src/content/observer.ts
@@ -15,6 +15,7 @@ import {
   type RenderOptions,
   renderDiffTable,
   type SideHeaderMode,
+  syncColumnWidths,
   syncRowHeights,
 } from "../renderer/tableRenderer";
 import { clearHeaderCache, fetchCsvHeaderRow } from "./headerFetcher";
@@ -48,6 +49,23 @@ export function initObserverLifecycle(): void {
   document.addEventListener("turbo:load", syncObserverWithRoute);
   document.addEventListener("pjax:end", syncObserverWithRoute);
   window.addEventListener("popstate", syncObserverWithRoute);
+
+  // Re-derive sticky offset + column widths on viewport resize: GitHub's sticky
+  // `top` and our column widths can both change at responsive breakpoints, which
+  // a per-element ResizeObserver alone may miss.
+  window.addEventListener("resize", handleViewportResize, { passive: true });
+
+  // Re-derive the sticky-top offset on scroll. GitHub applies the file-header's
+  // sticky `top` asynchronously (React/virtualization), so the inject-time read
+  // can land while it is still `auto` (→ offset short by ~58px, header hides
+  // behind GitHub's bar). Re-reading once scrolling begins self-heals it; the
+  // value is stable, so repeated reads are idempotent. rAF-throttled.
+  // Capture phase so scrolls from any nested scroll container are caught too
+  // (scroll events don't bubble, but capture-phase listeners still fire).
+  window.addEventListener("scroll", handleViewportScroll, {
+    passive: true,
+    capture: true,
+  });
 
   // Poll for URL changes that bypass Turbo/PJAX events (e.g. GitHub PR tab
   // switches via pushState in the main world, invisible to content script's
@@ -88,10 +106,186 @@ function disconnectObserver(): void {
   // Clear cached revision context and header cache on navigation
   clearRevisionContextCache();
   clearHeaderCache();
+  // Disconnect per-table ResizeObservers and cancel pending rAFs so they don't
+  // leak across navigations / Turbo snapshot caching.
+  teardownAllContainerStates();
   if (!observer) return;
   observer.disconnect();
   observer = null;
   console.debug("[GitHub Better CSV Diff] Observer disconnected");
+}
+
+// --- Sticky header offset + responsive column/row sync ---
+
+interface PerContainerState {
+  tableElement: HTMLElement;
+  container: HTMLElement;
+  wrapper: HTMLElement;
+  config: UiConfig;
+  observers: ResizeObserver[];
+  rafId: number | null;
+  syncing: boolean;
+  /** Last value written to --csv-diff-sticky-top; lets us skip no-op rewrites. */
+  lastStickyTop: string | null;
+}
+
+const containerStates = new Map<HTMLElement, PerContainerState>();
+
+/** A wrapper can only be measured while attached and not toggled to Raw Diff. */
+function isWrapperMeasurable(wrapper: HTMLElement): boolean {
+  return wrapper.isConnected && wrapper.style.display !== "none";
+}
+
+/**
+ * Set --csv-diff-sticky-top from GitHub's own sticky file-header geometry so the
+ * CSV header pins directly below it. `top` resolves to "auto" (NaN) if the
+ * selector misses; coerce to 0 (degrades to viewport-top sticky).
+ */
+function updateStickyTopOffset(
+  container: HTMLElement,
+  wrapper: HTMLElement,
+  config: UiConfig,
+  state?: PerContainerState,
+): void {
+  if (!isWrapperMeasurable(wrapper)) return;
+  const fileHeader = container.querySelector<HTMLElement>(
+    config.stickyFileHeaderSelector,
+  );
+  const next = fileHeader
+    ? `${(Number.parseFloat(getComputedStyle(fileHeader).top) || 0) + fileHeader.getBoundingClientRect().height}px`
+    : "0px";
+  if (!fileHeader) {
+    console.warn(
+      "[GitHub Better CSV Diff] Sticky file-header not found:",
+      config.stickyFileHeaderSelector,
+    );
+  }
+  // Skip the write (and its style recalc) when the value is unchanged — this
+  // runs for every container on every scroll rAF, so an unguarded setProperty
+  // would dirty the custom property each frame and force needless reflows.
+  if (state && state.lastStickyTop === next) return;
+  wrapper.style.setProperty("--csv-diff-sticky-top", next);
+  if (state) state.lastStickyTop = next;
+}
+
+/** Re-measure sticky offset + column widths + row heights for one table. */
+function resyncTable(state: PerContainerState): void {
+  if (!isWrapperMeasurable(state.wrapper)) return;
+  updateStickyTopOffset(state.container, state.wrapper, state.config, state);
+  syncColumnWidths(state.tableElement);
+  syncRowHeights(state.tableElement);
+}
+
+/**
+ * Schedule a coalesced resync. The `syncing` flag + rAF break the ResizeObserver
+ * feedback loop: our own width writes resize the observed body, but those
+ * callbacks land while `syncing` is still true and are ignored; the flag is
+ * released one frame later, after the self-induced resize has flushed.
+ */
+function scheduleResync(state: PerContainerState): void {
+  if (state.syncing || !isWrapperMeasurable(state.wrapper)) return;
+  if (state.rafId != null) cancelAnimationFrame(state.rafId);
+  state.rafId = requestAnimationFrame(() => {
+    state.rafId = null;
+    if (!isWrapperMeasurable(state.wrapper)) return;
+    state.syncing = true;
+    syncColumnWidths(state.tableElement);
+    syncRowHeights(state.tableElement);
+    requestAnimationFrame(() => {
+      state.syncing = false;
+    });
+  });
+}
+
+/**
+ * Initial sync + ResizeObserver registration for a freshly injected/rerendered
+ * table. Tears down any prior state for the container first.
+ */
+function setupTableObservers(
+  tableElement: HTMLElement,
+  container: HTMLElement,
+  wrapper: HTMLElement,
+  config: UiConfig,
+): void {
+  teardownContainerState(container);
+
+  const state: PerContainerState = {
+    tableElement,
+    container,
+    wrapper,
+    config,
+    observers: [],
+    rafId: null,
+    syncing: false,
+    lastStickyTop: null,
+  };
+  containerStates.set(container, state);
+
+  resyncTable(state);
+
+  // Re-sync columns/rows when a body resizes (font load, responsive width),
+  // guarded against the self-induced feedback loop.
+  for (const body of tableElement.querySelectorAll<HTMLElement>(
+    ".csv-diff-body",
+  )) {
+    const ro = new ResizeObserver(() => scheduleResync(state));
+    ro.observe(body);
+    state.observers.push(ro);
+  }
+
+  // Re-derive the sticky-top offset when GitHub's file-header changes height.
+  // Writing the CSS var doesn't resize the file-header, so no loop guard needed.
+  const fileHeader = container.querySelector<HTMLElement>(
+    config.stickyFileHeaderSelector,
+  );
+  if (fileHeader) {
+    const ro = new ResizeObserver(() =>
+      updateStickyTopOffset(container, wrapper, config, state),
+    );
+    ro.observe(fileHeader);
+    state.observers.push(ro);
+  }
+}
+
+function teardownContainerState(container: HTMLElement): void {
+  const state = containerStates.get(container);
+  if (!state) return;
+  for (const ro of state.observers) ro.disconnect();
+  if (state.rafId != null) cancelAnimationFrame(state.rafId);
+  containerStates.delete(container);
+}
+
+function teardownAllContainerStates(): void {
+  for (const container of [...containerStates.keys()]) {
+    teardownContainerState(container);
+  }
+}
+
+function handleViewportResize(): void {
+  for (const state of containerStates.values()) {
+    // The offset must apply synchronously so the sticky position is correct for
+    // the new viewport before paint; column/row sync is rAF-deferred via
+    // scheduleResync (which carries the ResizeObserver loop guard).
+    updateStickyTopOffset(state.container, state.wrapper, state.config, state);
+    scheduleResync(state);
+  }
+}
+
+let offsetUpdateScheduled = false;
+function handleViewportScroll(): void {
+  if (offsetUpdateScheduled) return;
+  offsetUpdateScheduled = true;
+  requestAnimationFrame(() => {
+    offsetUpdateScheduled = false;
+    for (const state of containerStates.values()) {
+      updateStickyTopOffset(
+        state.container,
+        state.wrapper,
+        state.config,
+        state,
+      );
+    }
+  });
 }
 
 function processExistingDiffs(): void {
@@ -107,11 +301,23 @@ function processExistingDiffs(): void {
 
   for (const container of [...previewContainers, ...classicContainers]) {
     if (container.hasAttribute(PROCESSED_ATTR)) {
-      // Wrapper still present — nothing to do
-      if (container.querySelector(".csv-diff-wrapper")) continue;
+      const wrapper = container.querySelector<HTMLElement>(".csv-diff-wrapper");
+      if (wrapper) {
+        // Wrapper present AND observer state live — fully processed, skip.
+        if (containerStates.has(container)) continue;
 
-      // Wrapper is gone (GitHub rebuilt diffBody on collapse/re-expand).
+        // Wrapper present but state gone: a Turbo snapshot / bfcache restore
+        // brought back the markup with all JS-attached listeners + observers
+        // stripped (disconnectObserver ran on before-cache). Drop the stale
+        // wrapper and fall through to a full re-init, which re-renders +
+        // re-injects and thereby re-attaches scroll/toggle listeners and
+        // re-registers observers.
+        wrapper.remove();
+      }
+
+      // Wrapper gone (collapse/re-expand rebuild, or removed just above).
       // Keep PROCESSED_ATTR so CSS hides raw diff on re-expand.
+      teardownContainerState(container);
       container.removeAttribute("data-csv-diff-raw");
     }
 
@@ -214,6 +420,8 @@ function processCsvDiffBlock(
 
     fetchAndRerender({
       wrapper: wrapper as HTMLElement,
+      container,
+      config,
       csvDiff,
       owner: ctx.owner,
       repo: ctx.repo,
@@ -280,6 +488,8 @@ function determineInitialSideMode(
 
 interface FetchAndRerenderParams {
   wrapper: HTMLElement;
+  container: HTMLElement;
+  config: UiConfig;
   csvDiff: CsvDiff;
   owner: string;
   repo: string;
@@ -295,6 +505,8 @@ interface FetchAndRerenderParams {
 async function fetchAndRerender(params: FetchAndRerenderParams): Promise<void> {
   const {
     wrapper,
+    container,
+    config,
     csvDiff,
     owner,
     repo,
@@ -332,7 +544,9 @@ async function fetchAndRerender(params: FetchAndRerenderParams): Promise<void> {
     const oldContainer = wrapper.querySelector(".csv-diff-container");
     if (oldContainer) {
       oldContainer.replaceWith(newTable);
-      syncRowHeights(newTable);
+      // Re-init sticky offset + column/row sync and re-register observers on the
+      // replacement table (the old container's observers are now stale).
+      setupTableObservers(newTable, container, wrapper, config);
     }
   } catch (error) {
     console.warn(
@@ -501,12 +715,11 @@ function injectTableOverlay(
     toggleBtn.classList.toggle("csv-diff-toggle-active", !isTableVisible);
     // Toggle raw-mode attribute so CSS stops hiding original content
     container.toggleAttribute("data-csv-diff-raw", isTableVisible);
-    // Re-sync row heights when toggling back to table view
+    // Re-sync sticky offset + column widths + row heights when toggling back to
+    // table view (all read 0 while the wrapper was display:none).
     if (!isTableVisible) {
-      const currentTable = wrapper.querySelector<HTMLElement>(
-        ".csv-diff-container",
-      );
-      if (currentTable) syncRowHeights(currentTable);
+      const state = containerStates.get(container);
+      if (state) resyncTable(state);
     }
   });
 
@@ -515,7 +728,7 @@ function injectTableOverlay(
   // Place wrapper inside diffBody so collapsing the file hides it too
   setOriginalChildrenVisible(false);
   diffBody.prepend(wrapper);
-  syncRowHeights(tableElement);
+  setupTableObservers(tableElement, container, wrapper, config);
   return true;
 }
 

--- a/src/content/observer.ts
+++ b/src/content/observer.ts
@@ -273,7 +273,10 @@ function handleViewportResize(): void {
 
 let offsetUpdateScheduled = false;
 function handleViewportScroll(): void {
-  if (offsetUpdateScheduled) return;
+  // The capture-phase listener stays installed for the page's lifetime; skip all
+  // per-scroll work on non-diff routes (or after teardown) where there's nothing
+  // to reposition.
+  if (containerStates.size === 0 || offsetUpdateScheduled) return;
   offsetUpdateScheduled = true;
   requestAnimationFrame(() => {
     offsetUpdateScheduled = false;

--- a/src/parser/uiConfig.ts
+++ b/src/parser/uiConfig.ts
@@ -15,6 +15,11 @@ export interface UiConfig {
   contentSelector: string;
   /** Selector for the header actions area where the toggle button is inserted. */
   actionsSelector: string;
+  /**
+   * Selector for GitHub's own sticky file-header bar. The CSV column header pins
+   * directly below it, so its rendered height drives the sticky-top offset.
+   */
+  stickyFileHeaderSelector: string;
   extractContent(cell: HTMLTableCellElement): string;
   /** Extract text from a changed (added/removed) content cell, stripping diff marker if present. */
   extractChangedContent(cell: HTMLTableCellElement): string;
@@ -31,6 +36,7 @@ export const PREVIEW_UI: UiConfig = {
   headerSelector: ":scope > :first-child",
   contentSelector: ":scope > :nth-child(2)",
   actionsSelector: '[class*="diffHeaderActionWrapper"], [class*="ActionGroup"]',
+  stickyFileHeaderSelector: 'div[class*="diffHeaderWrapper"]',
   extractContent: (cell) => cell.textContent ?? "",
   extractChangedContent: (cell) => {
     const text = cell.textContent ?? "";
@@ -53,6 +59,7 @@ export const CLASSIC_UI: UiConfig = {
   headerSelector: ".file-header",
   contentSelector: ".js-file-content",
   actionsSelector: ".file-actions > .d-flex",
+  stickyFileHeaderSelector: ".file-header",
   extractContent: (cell) =>
     cell.querySelector<HTMLElement>(".blob-code-inner")?.textContent ?? "",
   extractChangedContent: (cell) =>

--- a/src/renderer/tableRenderer.ts
+++ b/src/renderer/tableRenderer.ts
@@ -151,14 +151,21 @@ export function syncColumnWidths(container: HTMLElement): void {
     for (const col of [...headerCols, ...bodyCols]) col.style.width = "";
 
     // Read pass — per column, max(header, first body row) to avoid clipping.
-    const headerCells =
-      headerTable.querySelectorAll<HTMLElement>("thead tr > *");
+    const headerCells = Array.from(
+      headerTable.querySelectorAll<HTMLTableCellElement>("thead tr > *"),
+    );
+    // The loading header is a single th[colSpan=n], which doesn't map 1:1 to
+    // columns — its width would wrongly drive column 0 to the full table width.
+    // Measure from the body alone while any header cell spans multiple columns.
+    const hasSpanningHeaderCell = headerCells.some((cell) => cell.colSpan > 1);
     const bodyCells =
       bodyTable.querySelector<HTMLTableRowElement>("tbody tr")?.children ??
       null;
     const widths = new Array<number>(n);
     for (let c = 0; c < n; c++) {
-      const headerWidth = headerCells[c]?.getBoundingClientRect().width ?? 0;
+      const headerWidth = hasSpanningHeaderCell
+        ? 0
+        : (headerCells[c]?.getBoundingClientRect().width ?? 0);
       const bodyCell = bodyCells?.[c] as HTMLElement | undefined;
       const bodyWidth = bodyCell?.getBoundingClientRect().width ?? 0;
       widths[c] = Math.ceil(Math.max(headerWidth, bodyWidth));

--- a/src/renderer/tableRenderer.ts
+++ b/src/renderer/tableRenderer.ts
@@ -83,7 +83,7 @@ export function syncRowHeights(container: HTMLElement): void {
   if (!container.isConnected || !container.getClientRects().length) return;
 
   const tables = container.querySelectorAll<HTMLTableElement>(
-    ".csv-diff-side table",
+    ".csv-diff-body-table",
   );
   if (tables.length !== 2) return;
 
@@ -111,6 +111,97 @@ export function syncRowHeights(container: HTMLElement): void {
     const h = `${heights[i]}px`;
     beforeRows[i].style.height = h;
     afterRows[i].style.height = h;
+  }
+}
+
+/**
+ * Align each side's frozen header table columns with its body table columns.
+ * Header and body live in separate tables (so the header can escape the body's
+ * scroll container and stick to the viewport), so their column widths must be
+ * synced explicitly. Runs per side independently — Before/After widths need not
+ * match; only the intra-side header↔body columns must align.
+ *
+ * Must run after the container is inserted into the document; both this and
+ * syncRowHeights are connectivity-gated and no-op on a detached node.
+ */
+export function syncColumnWidths(container: HTMLElement): void {
+  if (!container.isConnected || !container.getClientRects().length) return;
+
+  const sides = container.querySelectorAll<HTMLElement>(".csv-diff-side");
+  for (const side of sides) {
+    const headerTable = side.querySelector<HTMLTableElement>(
+      ".csv-diff-header-table",
+    );
+    const bodyTable = side.querySelector<HTMLTableElement>(
+      ".csv-diff-body-table",
+    );
+    if (!headerTable || !bodyTable) continue;
+
+    const headerCols = headerTable.querySelectorAll<HTMLTableColElement>("col");
+    const bodyCols = bodyTable.querySelectorAll<HTMLTableColElement>("col");
+    const n = headerCols.length;
+    if (n === 0 || n !== bodyCols.length) continue;
+
+    // Clear pass — drop fixed layout and any width applied by a prior pass so
+    // the read pass measures true natural widths, not stale constrained ones.
+    for (const table of [headerTable, bodyTable]) {
+      table.style.tableLayout = "auto";
+      table.style.width = "";
+    }
+    for (const col of [...headerCols, ...bodyCols]) col.style.width = "";
+
+    // Read pass — per column, max(header, first body row) to avoid clipping.
+    const headerCells =
+      headerTable.querySelectorAll<HTMLElement>("thead tr > *");
+    const bodyCells =
+      bodyTable.querySelector<HTMLTableRowElement>("tbody tr")?.children ??
+      null;
+    const widths = new Array<number>(n);
+    for (let c = 0; c < n; c++) {
+      const headerWidth = headerCells[c]?.getBoundingClientRect().width ?? 0;
+      const bodyCell = bodyCells?.[c] as HTMLElement | undefined;
+      const bodyWidth = bodyCell?.getBoundingClientRect().width ?? 0;
+      widths[c] = Math.ceil(Math.max(headerWidth, bodyWidth));
+    }
+
+    // Fill the side's width when the natural columns are narrower than the
+    // available space (restoring the old width:100% behaviour) by distributing
+    // the slack across the data columns proportionally to their natural width;
+    // the line-number column (index 0) stays narrow. When the natural columns
+    // overflow, leave them as-is so the body scrolls horizontally.
+    const naturalTotal = widths.reduce((sum, w) => sum + w, 0);
+    const available = bodyTable.parentElement?.clientWidth ?? 0;
+    const dataCount = n - 1;
+    if (available > naturalTotal && dataCount > 0) {
+      const slack = available - naturalTotal;
+      const dataTotal = naturalTotal - widths[0];
+      let distributed = 0;
+      for (let c = 1; c < n; c++) {
+        // Give the remainder to the last data column so columns sum exactly.
+        const add =
+          c === n - 1
+            ? slack - distributed
+            : dataTotal > 0
+              ? Math.round((slack * widths[c]) / dataTotal)
+              : Math.round(slack / dataCount);
+        widths[c] += add;
+        distributed += add;
+      }
+    }
+
+    // Write pass — identical per-column + total widths on both tables, fixed
+    // layout, so their horizontal scroll ranges match exactly.
+    let total = 0;
+    for (let c = 0; c < n; c++) {
+      const w = `${widths[c]}px`;
+      headerCols[c].style.width = w;
+      bodyCols[c].style.width = w;
+      total += widths[c];
+    }
+    for (const table of [headerTable, bodyTable]) {
+      table.style.tableLayout = "fixed";
+      table.style.width = `${total}px`;
+    }
   }
 }
 
@@ -170,18 +261,32 @@ export function renderDiffTable(
 
   highlightChangedCells(container, matched);
 
-  // Synchronize horizontal scroll between Before and After sides
-  const sides = container.querySelectorAll<HTMLElement>(".csv-diff-side");
-  if (sides.length === 2) {
+  // Synchronize horizontal scroll between Before and After sides. The body is
+  // the only horizontal scroll container; mirror its scrollLeft to the other
+  // body AND to both header strips (overflow:hidden, scrolled programmatically)
+  // so the frozen headers track their columns. scrollLeft only — a whole-table
+  // transform would drag the sticky-left line-number column off too.
+  const bodies = container.querySelectorAll<HTMLElement>(".csv-diff-body");
+  const strips = container.querySelectorAll<HTMLElement>(
+    ".csv-diff-header-strip",
+  );
+  if (bodies.length === 2) {
     let syncing = false;
-    for (const side of sides) {
-      side.addEventListener("scroll", () => {
-        if (syncing) return;
-        syncing = true;
-        const other = side === sides[0] ? sides[1] : sides[0];
-        other.scrollLeft = side.scrollLeft;
-        syncing = false;
-      });
+    for (const body of bodies) {
+      body.addEventListener(
+        "scroll",
+        () => {
+          if (syncing) return;
+          syncing = true;
+          const left = body.scrollLeft;
+          for (const other of bodies) {
+            if (other !== body) other.scrollLeft = left;
+          }
+          for (const strip of strips) strip.scrollLeft = left;
+          syncing = false;
+        },
+        { passive: true },
+      );
     }
   }
 
@@ -204,14 +309,43 @@ function buildSide(
   headerDiv.textContent = label;
   sideDiv.appendChild(headerDiv);
 
+  // Header and body are separate tables so the header strip can escape the
+  // body's horizontal scroll container and stick to the viewport. Their column
+  // widths are aligned at runtime by syncColumnWidths.
+  sideDiv.appendChild(buildHeaderTable(headers, maxCols, isLoading));
+  sideDiv.appendChild(buildBodyTable(matched, side, maxCols));
+  return sideDiv;
+}
+
+/** Append a `<colgroup>` of `colCount` `<col>` elements as the table's width carrier. */
+function appendColgroup(table: HTMLTableElement, colCount: number): void {
+  const colgroup = document.createElement("colgroup");
+  for (let i = 0; i < colCount; i++) {
+    colgroup.appendChild(document.createElement("col"));
+  }
+  table.appendChild(colgroup);
+}
+
+/** Build the sticky header strip containing the column-header table. */
+function buildHeaderTable(
+  headers: string[],
+  maxCols: number,
+  isLoading: boolean,
+): HTMLElement {
+  const strip = document.createElement("div");
+  strip.className = "csv-diff-header-strip";
+
   const table = document.createElement("table");
+  table.className = "csv-diff-header-table";
+  const colCount = maxCols + 1; // +1 for the line number column
+  appendColgroup(table, colCount);
+
   const thead = document.createElement("thead");
   const headerRow = document.createElement("tr");
 
   if (isLoading) {
-    // Loading placeholder: single cell spanning all columns (line-num + data cols)
     const th = document.createElement("th");
-    th.colSpan = maxCols + 1; // +1 for line number column
+    th.colSpan = colCount;
     th.textContent = "Loading...";
     th.className = "csv-diff-loading";
     headerRow.appendChild(th);
@@ -230,6 +364,24 @@ function buildSide(
   }
   thead.appendChild(headerRow);
   table.appendChild(thead);
+
+  strip.appendChild(table);
+  return strip;
+}
+
+/** Build the horizontally-scrollable body containing the data-row table. */
+function buildBodyTable(
+  matched: MatchedRow[],
+  side: "before" | "after",
+  maxCols: number,
+): HTMLElement {
+  const bodyDiv = document.createElement("div");
+  bodyDiv.className = "csv-diff-body";
+
+  const table = document.createElement("table");
+  table.className = "csv-diff-body-table";
+  const colCount = maxCols + 1; // +1 for the line number column
+  appendColgroup(table, colCount);
 
   const tbody = document.createElement("tbody");
 
@@ -269,8 +421,8 @@ function buildSide(
   }
 
   table.appendChild(tbody);
-  sideDiv.appendChild(table);
-  return sideDiv;
+  bodyDiv.appendChild(table);
+  return bodyDiv;
 }
 
 function highlightChangedCells(

--- a/src/styles/diff-table.css
+++ b/src/styles/diff-table.css
@@ -3,7 +3,6 @@
 .csv-diff-container {
   display: flex;
   gap: 4px;
-  overflow-x: auto;
   font-family:
     ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
     monospace;
@@ -12,20 +11,44 @@
   color: var(--fgColor-default, #1f2328);
 }
 
+/* No overflow here: any scroll container would trap the header's position:sticky.
+   Horizontal scroll lives on .csv-diff-body; the header strip sticks to the page. */
 .csv-diff-side {
   flex: 1;
+  min-width: 0;
+}
+
+/* The only horizontal scroll container. Vertical scroll stays at the document
+   level so the header strip can pin to the viewport. */
+.csv-diff-body {
   overflow-x: auto;
 }
 
+/* Frozen header strip: pinned below GitHub's own sticky file-header bar.
+   --csv-diff-sticky-top is set at runtime from that bar's height (observer.ts);
+   overflow:hidden so it can be scrolled programmatically in sync with the body. */
+.csv-diff-header-strip {
+  position: sticky;
+  top: var(--csv-diff-sticky-top, 0px);
+  z-index: 3;
+  overflow: hidden;
+  background: var(--bgColor-muted, #f6f8fa);
+  box-shadow: 0 1px 0 var(--borderColor-default, #d0d7de);
+}
+
 .csv-diff-side table {
-  width: 100%;
   border-collapse: separate;
   border-spacing: 0;
+  table-layout: fixed;
+}
+
+/* Report full natural width so syncColumnWidths doesn't under-measure a header
+   that would otherwise wrap. */
+.csv-diff-header-table th {
+  white-space: nowrap;
 }
 
 .csv-diff-side th {
-  position: sticky;
-  top: 0;
   background: var(--bgColor-muted, #f6f8fa);
   padding: 4px 8px;
   text-align: left;


### PR DESCRIPTION
## Summary

Closes #11.

Renders the CSV diff table's column header as a viewport-sticky row that stays visible while scrolling, pinned directly below GitHub's own sticky file-header bar (stacking with it). Works across Classic and Preview UIs, unified and split layouts.

## Why this approach

`position: sticky` on the header was already declared in CSS but never engaged: the `overflow-x: auto` on the scroll container forces `overflow-y` to `auto` (CSS overflow spec), turning it into a vertical scroll container that traps the sticky header — and since that container never actually scrolls vertically (the document does), the header just scrolled away.

To pin to the viewport while still allowing horizontal scroll for wide tables, the header must not be a descendant of the horizontal scroller. So each side is split into a separate sticky header table and a horizontally-scrollable body table (the standard "frozen header" pattern), with column widths and horizontal scroll synced in JS, and the sticky `top` derived at runtime from GitHub's file-header geometry.

## Changes

- **UiConfig**: add `stickyFileHeaderSelector` (Preview: `diffHeaderWrapper`, Classic: `.file-header`).
- **Renderer**: split each side into a header-strip table + body table with `<colgroup>` width carriers; `syncColumnWidths` aligns the two tables' columns and fills the available width (distributing slack to data columns); horizontal scroll mirrors the body to the other body and both header strips.
- **CSS**: drop the `overflow-x` trap, add the sticky `.csv-diff-header-strip` pinned at `--csv-diff-sticky-top` with z-index stacking and a subtle shadow.
- **Observer**: set the runtime sticky-top offset and keep it + column/row sync current via per-container `ResizeObserver`s (feedback-loop-guarded) plus window `resize`/`scroll`; tear down on navigation; fully re-init restored (Turbo snapshot / bfcache) wrappers whose listeners were stripped.

## Verification

Manual, via `playwright-cli --extension` against the PR #2 test samples:

- Header pins directly below GitHub's file-header bar (~100–101px) while body rows scroll under it — verified in Classic + Preview, unified + split.
- Horizontal scroll keeps header/body columns aligned; the line-number column stays frozen-left.
- Data columns fill the available width; wide tables scroll horizontally.
- Exercised collapse/expand and async-fetched headers; no observer leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV diff tables now preserve sticky header positioning and re-sync column/row sizing after dynamic layout changes and view toggles.
  * Header fetches and re-renders automatically re-establish table sync for correct alignment.

* **Bug Fixes**
  * Fixed stale/hidden wrappers restoring original content and preventing misaligned diffs after navigations/restores.

* **Style**
  * Table layout and scrolling behavior updated to improve header pinning and prevent wrapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letconst/github-better-csv-diff/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->