### PR TITLE
chore: strip console.debug/log from production builds

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,9 +1,41 @@
+import { type Plugin, transformWithEsbuild } from "vite";
 import { defineConfig } from "wxt";
+
+// Drops dev-only console.debug/log calls from production bundles while keeping
+// console.warn/error, which the project intentionally uses to surface errors.
+// WXT ignores top-level `esbuild` config from the vite() hook, so this runs as
+// a Vite plugin: esbuild marks the calls pure, and minifySyntax removes them
+// because their return value is unused.
+function stripDebugLogs(): Plugin {
+  return {
+    name: "strip-debug-logs",
+    apply: "build",
+    async transform(code, id) {
+      if (!/\.[jt]sx?$/.test(id)) return null;
+      if (!code.includes("console.debug") && !code.includes("console.log")) {
+        return null;
+      }
+      const result = await transformWithEsbuild(code, id, {
+        pure: ["console.debug", "console.log"],
+        minifySyntax: true,
+      });
+      return { code: result.code, map: result.map };
+    },
+  };
+}
 
 export default defineConfig({
   srcDir: "src",
   outDir: "dist",
   modules: ["@wxt-dev/auto-icons"],
+  // Strip dev-only noise (console.debug/log) from production bundles while
+  // keeping console.warn/error, which the project intentionally uses to
+  // surface errors. esbuild's `pure` lets minification drop these calls
+  // because their return value is unused; dev builds skip minify, so the
+  // calls remain there for debugging.
+  vite: (env) => ({
+    plugins: env.mode === "production" ? [stripDebugLogs()] : [],
+  }),
   autoIcons: {
     baseIconPath: "assets/icon.svg",
   },


### PR DESCRIPTION
## Summary

Strip `console.debug` and `console.log` calls from production bundles while preserving `console.warn` and `console.error`, which the project intentionally uses to surface errors per `CLAUDE.md`.

## Why

The production bundle was shipping dev-only noise:

- `src/entrypoints/content.ts` — `console.log("...Content script loaded")`
- `src/content/observer.ts` — two `console.debug` calls for observer connect/disconnect

Users see this noise in their browser DevTools console with no actionable value. Stripping `warn`/`error` was rejected as it would break the project's "do not swallow errors silently" contract.

## How

An inline Vite plugin in `wxt.config.ts`, gated to `env.mode === "production"`, uses Vite's public `transformWithEsbuild` API. esbuild's `pure: ["console.debug", "console.log"]` marks those calls as side-effect-free, and `minifySyntax: true` drops them because their return value is unused.

```typescript
function stripDebugLogs(): Plugin {
  return {
    name: "strip-debug-logs",
    apply: "build",
    async transform(code, id) {
      if (!/\.[jt]sx?$/.test(id)) return null;
      if (!code.includes("console.debug") && !code.includes("console.log")) {
        return null;
      }
      const result = await transformWithEsbuild(code, id, {
        pure: ["console.debug", "console.log"],
        minifySyntax: true,
      });
      return { code: result.code, map: result.map };
    },
  };
}
```

### Why a plugin instead of top-level `esbuild.pure`?

The natural first attempt — returning `{ esbuild: { pure: [...] } }` from the `vite()` hook — silently does nothing. WXT does not honor a top-level `esbuild` option from that hook (verified empirically: even `esbuild.drop: ["console"]` removed zero calls). WXT's documented extension point is the `plugins` array, so the strip is implemented as a Vite plugin.

### Design properties

- **Zero new dependencies.** `transformWithEsbuild` is a public Vite export.
- **No source-file changes.** Only `wxt.config.ts` is touched; the 18 existing `console.*` call sites are untouched.
- **Dev builds keep logs.** The plugin is only registered when `env.mode === "production"`, so `wxt dev` retains all calls for debugging.
- **`warn`/`error` preserved.** They are not in the `pure` list.

## Verification

Production bundles (`dist/chrome-mv3/content-scripts/content.js` and `dist/firefox-mv2/content-scripts/content.js`):

| Call | Before | After |
|---|---|---|
| `console.log` | 1 | **0** |
| `console.debug` | 2 | **0** |
| `console.warn` | 13 | 13 |
| `console.error` | 1 | 1 |

`npm run lint` passes (the 3 pre-existing warnings in `src/renderer` are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production builds by removing debug and console logging statements, resulting in smaller bundle sizes and cleaner production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/letconst/github-better-csv-diff/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->