### PR TITLE
refactor: remove dead code and centralize diff route parsing

### DIFF
--- a/src/content/observer.ts
+++ b/src/content/observer.ts
@@ -32,8 +32,6 @@ const CSV_EXTENSIONS = [".csv", ".tsv"];
 
 let observer: MutationObserver | null = null;
 let debouncedCallback: CancellableCallback | null = null;
-// biome-ignore lint/correctness/noUnusedVariables: retained for future teardown
-let urlPollTimer: ReturnType<typeof setInterval> | null = null;
 let lifecycleInitialized = false;
 
 export function initObserverLifecycle(): void {
@@ -70,8 +68,9 @@ export function initObserverLifecycle(): void {
   // Poll for URL changes that bypass Turbo/PJAX events (e.g. GitHub PR tab
   // switches via pushState in the main world, invisible to content script's
   // isolated world). Safe if DOM isn't ready: processExistingDiffs is idempotent,
-  // and the MutationObserver will catch later inserts.
-  urlPollTimer = watchUrlChanges(syncObserverWithRoute);
+  // and the MutationObserver will catch later inserts. The interval lives for
+  // the page's lifetime by design, so its handle is not retained.
+  watchUrlChanges(syncObserverWithRoute);
 
   // Initial route check
   syncObserverWithRoute();
@@ -751,11 +750,9 @@ function injectTableOverlay(
  * script's isolated world (e.g. pushState called by the page's main world).
  * Compares pathname only — query/hash changes don't affect route gating.
  */
-function watchUrlChanges(
-  onNavigate: () => void,
-): ReturnType<typeof setInterval> {
+function watchUrlChanges(onNavigate: () => void): void {
   let lastPathname = location.pathname;
-  return setInterval(() => {
+  setInterval(() => {
     if (location.pathname !== lastPathname) {
       lastPathname = location.pathname;
       onNavigate();

--- a/src/content/revisionContext.ts
+++ b/src/content/revisionContext.ts
@@ -10,6 +10,8 @@
  *   branch is updated while viewing. Same-repo compares only.
  */
 
+import { parseDiffRoute } from "./routes";
+
 export interface RevisionContext {
   owner: string;
   repo: string;
@@ -53,71 +55,40 @@ function refsFromSha(sha: string): Refs {
 }
 
 function resolveRefs(pathname: string): Refs {
-  if (isStandaloneCommitRoute(pathname)) {
-    const sha = extractStandaloneCommitSha(pathname);
-    return extractCommitRefs() ?? (sha ? refsFromSha(sha) : NO_REFS);
-  }
+  const route = parseDiffRoute(pathname);
+  if (!route) return NO_REFS;
 
-  if (isPrCommitRoute(pathname)) {
-    const sha = extractCommitShaFromUrl(pathname);
-    return (
-      extractCommitRefs() ??
-      extractPreviewPrRefs() ??
-      (sha ? refsFromSha(sha) : NO_REFS)
-    );
-  }
+  switch (route.kind) {
+    case "commit":
+      return extractCommitRefs() ?? refsFromSha(route.sha);
 
-  if (isPreviewPrRoute(pathname)) {
-    return extractPreviewPrRefs() ?? NO_REFS;
-  }
+    case "pr-commit":
+      return (
+        extractCommitRefs() ?? extractPreviewPrRefs() ?? refsFromSha(route.sha)
+      );
 
-  if (isClassicPrRoute(pathname)) {
-    // Classic UI: only headRef is reliable (end_commit_oid).
-    // baseRef (base_commit_oid) is the head's parent, not the merge base.
-    const el = document.querySelector<HTMLElement>(
-      '[data-url*="show_partial_comparison"]',
-    );
-    if (el) {
-      const dataUrl = el.getAttribute("data-url") ?? "";
-      return {
-        baseRef: null,
-        headRef: extractUrlParam(dataUrl, "end_commit_oid"),
-      };
+    case "pr-changes":
+      return extractPreviewPrRefs() ?? NO_REFS;
+
+    case "pr-files": {
+      // Classic UI: only headRef is reliable (end_commit_oid).
+      // baseRef (base_commit_oid) is the head's parent, not the merge base.
+      const el = document.querySelector<HTMLElement>(
+        '[data-url*="show_partial_comparison"]',
+      );
+      if (el) {
+        const dataUrl = el.getAttribute("data-url") ?? "";
+        return {
+          baseRef: null,
+          headRef: extractUrlParam(dataUrl, "end_commit_oid"),
+        };
+      }
+      return NO_REFS;
     }
-    return NO_REFS;
+
+    case "compare":
+      return parseCompareRefs(route.spec);
   }
-
-  if (isCompareRoute(pathname)) {
-    return parseCompareRefs(pathname) ?? NO_REFS;
-  }
-
-  return NO_REFS;
-}
-
-// --- Route detection helpers ---
-
-function isPreviewPrRoute(pathname: string): boolean {
-  return /^\/[^/]+\/[^/]+\/pull\/\d+\/changes\/?$/i.test(pathname);
-}
-
-function isClassicPrRoute(pathname: string): boolean {
-  return /^\/[^/]+\/[^/]+\/pull\/\d+\/files\/?$/i.test(pathname);
-}
-
-/** Standalone commit page: /owner/repo/commit/:sha */
-function isStandaloneCommitRoute(pathname: string): boolean {
-  return /^\/[^/]+\/[^/]+\/commit\/[0-9a-f]{7,40}\/?$/i.test(pathname);
-}
-
-/** PR commit pages: /pull/:id/changes/:sha or /pull/:id/commits/:sha */
-function isPrCommitRoute(pathname: string): boolean {
-  return /^\/[^/]+\/[^/]+\/pull\/\d+\/(changes|commits)\/[0-9a-f]{7,40}\/?$/i.test(
-    pathname,
-  );
-}
-
-function isCompareRoute(pathname: string): boolean {
-  return /^\/[^/]+\/[^/]+\/compare\/.+$/i.test(pathname);
 }
 
 // --- Parsing helpers ---
@@ -133,20 +104,6 @@ function extractUrlParam(url: string, param: string): string | null {
   if (queryStart === -1) return null;
   const params = new URLSearchParams(url.slice(queryStart));
   return params.get(param);
-}
-
-/** Extract commit sha from standalone commit URL like /owner/repo/commit/:sha */
-function extractStandaloneCommitSha(pathname: string): string | null {
-  const match = pathname.match(/\/commit\/([0-9a-f]{7,40})\/?$/i);
-  return match ? match[1] : null;
-}
-
-/** Extract commit sha from PR commit URLs like /pull/:id/commits/:sha or /pull/:id/changes/:sha */
-function extractCommitShaFromUrl(pathname: string): string | null {
-  const match = pathname.match(
-    /\/pull\/\d+\/(?:commits|changes)\/([0-9a-f]{7,40})\/?$/i,
-  );
-  return match ? match[1] : null;
 }
 
 function extractCommitRefs(): {
@@ -205,16 +162,10 @@ function extractPreviewPrRefs(): {
   return null;
 }
 
-function parseCompareRefs(pathname: string): {
-  baseRef: string | null;
-  headRef: string | null;
-} | null {
-  const match = pathname.match(/^\/[^/]+\/[^/]+\/compare\/(.+)$/i);
-  if (!match) return null;
-
-  const compareSpec = match[1];
+/** Resolve refs from a compare spec like "main...feature" (already URL-stripped). */
+function parseCompareRefs(compareSpec: string): Refs {
   const separatorIndex = compareSpec.indexOf("...");
-  if (separatorIndex === -1) return null;
+  if (separatorIndex === -1) return NO_REFS;
 
   const rawBase = decodeURIComponent(compareSpec.slice(0, separatorIndex));
   const rawHead = decodeURIComponent(compareSpec.slice(separatorIndex + 3));

--- a/src/content/routes.ts
+++ b/src/content/routes.ts
@@ -1,6 +1,7 @@
 /**
  * Route detection for GitHub diff-related pages.
- * Used to gate MutationObserver startup to pages that actually contain diffs.
+ * Single source of truth for the URL pattern of every supported diff route —
+ * used both to gate MutationObserver startup and to resolve revision refs.
  */
 
 // Matched routes:
@@ -15,15 +16,36 @@
 //   /owner/repo/pull/123              (conversation tab)
 //   /owner/repo/issues                (issues list)
 //   /owner/repo                       (repo root)
-const DIFF_ROUTE_PATTERNS: RegExp[] = [
-  /^\/[^/]+\/[^/]+\/pull\/\d+\/files\/?$/i,
-  /^\/[^/]+\/[^/]+\/pull\/\d+\/changes\/?$/i,
-  /^\/[^/]+\/[^/]+\/pull\/\d+\/changes\/[0-9a-f]{7,40}\/?$/i,
-  /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{7,40}\/?$/i,
-  /^\/[^/]+\/[^/]+\/commit\/[0-9a-f]{7,40}\/?$/i,
-  /^\/[^/]+\/[^/]+\/compare\/.+$/i,
-];
+
+export type DiffRoute =
+  | { kind: "pr-files" }
+  | { kind: "pr-changes" }
+  | { kind: "pr-commit"; sha: string }
+  | { kind: "commit"; sha: string }
+  | { kind: "compare"; spec: string };
+
+const PR_FILES_RE = /^\/[^/]+\/[^/]+\/pull\/\d+\/files\/?$/i;
+const PR_CHANGES_RE = /^\/[^/]+\/[^/]+\/pull\/\d+\/changes\/?$/i;
+const PR_COMMIT_RE =
+  /^\/[^/]+\/[^/]+\/pull\/\d+\/(?:changes|commits)\/([0-9a-f]{7,40})\/?$/i;
+const COMMIT_RE = /^\/[^/]+\/[^/]+\/commit\/([0-9a-f]{7,40})\/?$/i;
+const COMPARE_RE = /^\/[^/]+\/[^/]+\/compare\/(.+)$/i;
+
+/** Classify the pathname as one of the supported diff routes, or null. */
+export function parseDiffRoute(
+  pathname: string = location.pathname,
+): DiffRoute | null {
+  if (PR_FILES_RE.test(pathname)) return { kind: "pr-files" };
+  if (PR_CHANGES_RE.test(pathname)) return { kind: "pr-changes" };
+  const prCommit = pathname.match(PR_COMMIT_RE);
+  if (prCommit) return { kind: "pr-commit", sha: prCommit[1] };
+  const commit = pathname.match(COMMIT_RE);
+  if (commit) return { kind: "commit", sha: commit[1] };
+  const compare = pathname.match(COMPARE_RE);
+  if (compare) return { kind: "compare", spec: compare[1] };
+  return null;
+}
 
 export function isDiffRoute(pathname: string = location.pathname): boolean {
-  return DIFF_ROUTE_PATTERNS.some((re) => re.test(pathname));
+  return parseDiffRoute(pathname) !== null;
 }

--- a/src/parser/csvParser.ts
+++ b/src/parser/csvParser.ts
@@ -4,17 +4,6 @@
 
 import Papa from "papaparse";
 
-export function parseCsv(raw: string): string[][] {
-  const result = Papa.parse<string[]>(raw, {
-    header: false,
-    skipEmptyLines: true,
-  });
-  if (result.errors.length > 0) {
-    console.warn("[GitHub Better CSV Diff] CSV parse errors:", result.errors);
-  }
-  return result.data;
-}
-
 /**
  * Parses CSV while tracking which physical input line each CSV row starts on.
  * Uses Papa's `step` callback with `meta.cursor` to map character offsets

--- a/src/parser/diffParser.ts
+++ b/src/parser/diffParser.ts
@@ -56,36 +56,6 @@ export function getFirstLineNumbers(lines: DiffLine[]): {
   return { firstBeforeLine, firstAfterLine };
 }
 
-export function parseUnifiedDiff(diffText: string): DiffLine[] {
-  const lines = diffText.split("\n");
-  const result: DiffLine[] = [];
-
-  function makeLine(type: DiffLine["type"], content: string): DiffLine {
-    return { type, content, oldLineNumber: null, newLineNumber: null };
-  }
-
-  for (const line of lines) {
-    if (
-      line.startsWith("@@") ||
-      line.startsWith("--- ") ||
-      line.startsWith("+++ ") ||
-      line.startsWith("\\")
-    ) {
-      continue;
-    }
-
-    if (line.startsWith("+")) {
-      result.push(makeLine("added", line.slice(1)));
-    } else if (line.startsWith("-")) {
-      result.push(makeLine("removed", line.slice(1)));
-    } else if (line.startsWith(" ")) {
-      result.push(makeLine("unchanged", line.slice(1)));
-    }
-  }
-
-  return result;
-}
-
 export function diffToCsv(lines: DiffLine[]): CsvDiff {
   const beforeLines: string[] = [];
   const afterLines: string[] = [];

--- a/src/renderer/tableRenderer.ts
+++ b/src/renderer/tableRenderer.ts
@@ -486,7 +486,7 @@ function lineNumAt(nums: Array<number | null>, i: number): number | null {
   return nums[i] ?? null;
 }
 
-export function matchRows(
+function matchRows(
   before: string[][],
   after: string[][],
   beforeLineNums: Array<number | null>,
@@ -661,13 +661,13 @@ function tryPairBlock(
   const rKeys = new Map<string, number>();
   for (let j = 0; j < removedBlock.length; j++) {
     const key = beforeData[removedBlock[j].beforeIndex!]?.[0] ?? "";
-    if (!key || rKeys.has(key)) return emitOriginalOrder(blockTokens);
+    if (!key || rKeys.has(key)) return [...blockTokens];
     rKeys.set(key, j);
   }
   const aKeys = new Map<string, number>();
   for (let j = 0; j < addedBlock.length; j++) {
     const key = afterData[addedBlock[j].afterIndex!]?.[0] ?? "";
-    if (!key || aKeys.has(key)) return emitOriginalOrder(blockTokens);
+    if (!key || aKeys.has(key)) return [...blockTokens];
     aKeys.set(key, j);
   }
 
@@ -684,7 +684,7 @@ function tryPairBlock(
   // Verify monotonic on removed side
   let lastR = -1;
   for (const m of matches) {
-    if (m.rIdx < lastR) return emitOriginalOrder(blockTokens);
+    if (m.rIdx < lastR) return [...blockTokens];
     lastR = m.rIdx;
   }
 
@@ -735,10 +735,6 @@ function tryPairBlock(
   }
 
   return result;
-}
-
-function emitOriginalOrder(blockTokens: RowToken[]): PairedToken[] {
-  return [...blockTokens];
 }
 
 function matchByAlignment(


### PR DESCRIPTION
## Summary

First pass of applying the project's KISS/YAGNI coding rules, from a full-codebase audit. Behavior-preserving: deletions and deduplication only.

### Stage 1 — Dead code removal
- Remove `parseUnifiedDiff` (superseded by `extractDiffLinesFromDom`) and `parseCsv` (superseded by `parseCsvWithLineMap`) — no callers
- Drop the retained `urlPollTimer` handle (and its biome-ignore): the URL poll lives for the page lifetime by design, so no teardown will ever need it
- Unexport `matchRows` (only used within `tableRenderer.ts`) and inline the one-line `emitOriginalOrder` wrapper

### Stage 2 — Route parsing centralization
- `routes.ts` is now the single source of truth for diff-route URL patterns: `parseDiffRoute()` returns a discriminated union (`pr-files | pr-changes | pr-commit {sha} | commit {sha} | compare {spec}`)
- `revisionContext.ts` switches on the parsed route instead of keeping its own copies of the same regexes; its 5 route predicates and 2 sha extractors are deleted
- Rationale: the URL structure is an uncontrolled external dependency (like the GitHub DOM) — a GitHub route change previously required touching two files in sync

## Verification

- `npm run build` passes; bundle shrank 65.22 kB → 64.83 kB
- `npm run lint` / `tsc --noEmit` show only pre-existing findings (verified identical on `main` via stash): 3 Biome warnings and 4 type errors in `extractCommitRefs`, untouched by this PR

## Not in this PR (deferred until change-pain)

- Extracting the pure-logic `matchRows` family from `tableRenderer.ts` into a `rowMatcher.ts`
- Splitting `observer.ts` responsibilities
- Making `SideHeaderMode` a discriminated union

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal diff-route URL handling and revision reference detection across multiple modules.
  * Unified GitHub page route detection into a centralized routing system.
  * Removed deprecated internal helper functions from parsing modules.
  * Optimized table row alignment and pairing logic by streamlining intermediate processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->